### PR TITLE
Make Composite Command also work with pure ICommands

### DIFF
--- a/src/org/haxecommons/async/command/impl/CompositeCommand.hx
+++ b/src/org/haxecommons/async/command/impl/CompositeCommand.hx
@@ -110,6 +110,9 @@ class CompositeCommand extends AbstractProgressOperation implements ICompositeCo
 	 * @inheritDoc
 	 */
 	public function addCommandAt(command:ICommand, index:Int):ICompositeCommand {
+		#if debug
+		if(command == null) throw "the command argument must not be null.";
+		#end
 		if(index < commands.length) {
 			commands.insert(index, command);
 			total++;
@@ -148,7 +151,9 @@ class CompositeCommand extends AbstractProgressOperation implements ICompositeCo
 		Log.trace("Executing command: " + command);
 		#end
 		currentCommand = command;
-		addCommandListeners(cast(command, IOperation));
+		if(Std.is(command, IOperation)) {
+			addCommandListeners(cast(command, IOperation));
+		}
 		dispatchEvent(new CommandEvent(CommandEvent.EXECUTE, command));
 		dispatchBeforeCommandEvent(command);
 		command.execute();
@@ -236,7 +241,9 @@ class CompositeCommand extends AbstractProgressOperation implements ICompositeCo
 		Log.trace('Asynchronous command ${event.target} returned result. Executing next command.');
 		#end
 		removeCommandListeners(cast(event.target, IOperation));
-		dispatchAfterCommandEvent(cast(event.target, ICommand));
+		if(Std.is(event.target, ICommand)) {
+			dispatchAfterCommandEvent(cast(event.target, ICommand));
+		}
 		if(kind == CompositeCommandKind.SEQUENCE) executeNextCommand();
 		else if(kind == CompositeCommandKind.PARALLEL) removeCommand(cast(event.target, IOperation));
 	}

--- a/src/org/haxecommons/async/command/impl/CompositeCommand.hx
+++ b/src/org/haxecommons/async/command/impl/CompositeCommand.hx
@@ -73,7 +73,7 @@ class CompositeCommand extends AbstractProgressOperation implements ICompositeCo
 	 * @inheritDoc
 	 */
 	public function execute():Dynamic {
-		if(commands != null) {
+		if(commands.length > 0) {
 			if(kind == CompositeCommandKind.SEQUENCE) {
 				#if debug
 				Log.trace('Executing composite command $this in sequence.');
@@ -203,20 +203,20 @@ class CompositeCommand extends AbstractProgressOperation implements ICompositeCo
 	}
 
 	function executeCommandsInParallel() {
-		var operations:Array<ICommand> = []; 
-		for(command in commands) {
+		var commandsToExecute:Array<ICommand> = commands.concat([]); 
+		for(command in commandsToExecute) {
 			if(Std.is(command, IOperation)) {
-				operations[operations.length] = command;
 				addCommandListeners(cast(command, IOperation));
 			}
 			dispatchBeforeCommandEvent(command);
 			command.execute();
 			if(!Std.is(command, IOperation)) {
 				dispatchAfterCommandEvent(command);
+
+				commands.remove(command);
+				if(commands.length == 0) dispatchCompleteEvent();
 			}
 		}
-		commands = operations;
-		if(commands.length == 0) dispatchCompleteEvent();
 	}
 
 	/**

--- a/src/org/haxecommons/async/command/impl/CompositeCommand.hx
+++ b/src/org/haxecommons/async/command/impl/CompositeCommand.hx
@@ -211,9 +211,12 @@ class CompositeCommand extends AbstractProgressOperation implements ICompositeCo
 			}
 			dispatchBeforeCommandEvent(command);
 			command.execute();
-			if(!Std.is(command, IOperation)) dispatchAfterCommandEvent(command);
+			if(!Std.is(command, IOperation)) {
+				dispatchAfterCommandEvent(command);
+				commands.remove(command);
+			}
 		}
-		if(!containsOperations) dispatchCompleteEvent();
+		if(!containsOperations || commands.length == 0) dispatchCompleteEvent();
 	}
 
 	/**

--- a/src/org/haxecommons/async/command/impl/CompositeCommand.hx
+++ b/src/org/haxecommons/async/command/impl/CompositeCommand.hx
@@ -204,19 +204,20 @@ class CompositeCommand extends AbstractProgressOperation implements ICompositeCo
 
 	function executeCommandsInParallel() {
 		var containsOperations = false;
+		var operations:Array<ICommand> = []; 
 		for(command in commands) {
 			if(Std.is(command, IOperation)) {
-				containsOperations = true;
+				operations[operations.length] = command;
 				addCommandListeners(cast(command, IOperation));
 			}
 			dispatchBeforeCommandEvent(command);
 			command.execute();
 			if(!Std.is(command, IOperation)) {
 				dispatchAfterCommandEvent(command);
-				commands.remove(command);
 			}
 		}
-		if(!containsOperations || commands.length == 0) dispatchCompleteEvent();
+		commands = operations;
+		if(commands.length == 0) dispatchCompleteEvent();
 	}
 
 	/**

--- a/src/org/haxecommons/async/command/impl/CompositeCommand.hx
+++ b/src/org/haxecommons/async/command/impl/CompositeCommand.hx
@@ -203,7 +203,6 @@ class CompositeCommand extends AbstractProgressOperation implements ICompositeCo
 	}
 
 	function executeCommandsInParallel() {
-		var containsOperations = false;
 		var operations:Array<ICommand> = []; 
 		for(command in commands) {
 			if(Std.is(command, IOperation)) {


### PR DESCRIPTION
Not all IOperations are also ICommands and the other way around. Those parts threw exceptions when using the CompostiteCommand with both.